### PR TITLE
fix: retry network errors

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -27,7 +28,10 @@ func New() *Client {
 	rc.Logger = nil
 	rc.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		if err != nil {
-			return true, err
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return false, err
+			}
+			return true, nil
 		}
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
 			return true, nil

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -1,6 +1,11 @@
 package internal
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -13,5 +18,73 @@ func TestSetRetryWaitOrder(t *testing.T) {
 	}
 	if c.client.RetryWaitMin != 500*time.Millisecond || c.client.RetryWaitMax != 2*time.Second {
 		t.Fatalf("unexpected values: %v %v", c.client.RetryWaitMin, c.client.RetryWaitMax)
+	}
+}
+
+func TestCheckRetryNetworkError(t *testing.T) {
+	c := New()
+	if retry, err := c.client.CheckRetry(context.Background(), nil, errors.New("network")); !retry || err != nil {
+		t.Fatalf("expected retry with nil error, got %v, %v", retry, err)
+	}
+	if retry, err := c.client.CheckRetry(context.Background(), nil, context.Canceled); retry || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got retry %v err %v", retry, err)
+	}
+}
+
+type roundTripper func(*http.Request) (*http.Response, error)
+
+func (rt roundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return rt(r) }
+
+func TestCheckRetryStatusCodes(t *testing.T) {
+	c := New()
+	tests := []struct {
+		code      int
+		wantRetry bool
+	}{
+		{http.StatusOK, false},
+		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, true},
+	}
+	for _, tt := range tests {
+		resp := &http.Response{StatusCode: tt.code}
+		retry, err := c.client.CheckRetry(context.Background(), resp, nil)
+		if err != nil {
+			t.Fatalf("unexpected error for code %d: %v", tt.code, err)
+		}
+		if retry != tt.wantRetry {
+			t.Errorf("code %d: retry=%v want %v", tt.code, retry, tt.wantRetry)
+		}
+	}
+}
+
+func TestDoRetriesNetworkError(t *testing.T) {
+	c := New()
+	c.SetRetryWait(0, 0)
+	attempts := 0
+	rt := roundTripper(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, errors.New("temporary")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c.client.HTTPClient.Transport = rt
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating request: %v", err)
+	}
+	resp, err := c.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
 	}
 }


### PR DESCRIPTION
## Summary
- retry transient network failures instead of aborting
- add tests for network retry logic and status code handling

## Testing
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run`
- `go build -o /tmp/example ./example`


------
https://chatgpt.com/codex/tasks/task_e_68bf218c229c8333ac4d7aad6656a6d2