### PR TITLE
test: add error handling tests

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -5,19 +5,23 @@ import (
 	"testing"
 )
 
-func TestErrorFormatting(t *testing.T) {
-	e := &Error{Op: "op"}
-	if e.Error() != "op" {
-		t.Fatalf("unexpected: %q", e.Error())
-	}
-	inner := errors.New("boom")
-	e = &Error{Op: "op", Err: inner}
-	if e.Error() != "op: boom" {
-		t.Fatalf("unexpected: %q", e.Error())
-	}
+func TestErrorErrorFormatting(t *testing.T) {
+	t.Run("without inner error", func(t *testing.T) {
+		e := &Error{Op: "op"}
+		if got := e.Error(); got != "op" {
+			t.Fatalf("unexpected: %q", got)
+		}
+	})
+	t.Run("with inner error", func(t *testing.T) {
+		inner := errors.New("boom")
+		e := &Error{Op: "op", Err: inner}
+		if got := e.Error(); got != "op: boom" {
+			t.Fatalf("unexpected: %q", got)
+		}
+	})
 }
 
-func TestErrorIsAndUnwrap(t *testing.T) {
+func TestErrorIs(t *testing.T) {
 	inner := errors.New("x")
 	e := &Error{Kind: ErrNotFound, Err: inner}
 	if !errors.Is(e, &Error{Kind: ErrNotFound}) {
@@ -26,7 +30,12 @@ func TestErrorIsAndUnwrap(t *testing.T) {
 	if errors.Is(e, &Error{Kind: ErrServer}) {
 		t.Fatalf("unexpected match")
 	}
-	if errors.Unwrap(e) != inner {
+}
+
+func TestErrorUnwrap(t *testing.T) {
+	inner := errors.New("x")
+	e := &Error{Err: inner}
+	if got := errors.Unwrap(e); got != inner {
 		t.Fatalf("unwrap mismatch")
 	}
 }


### PR DESCRIPTION
## Summary
- add tests for Error formatting with and without inner error
- verify errors.Is matches on ErrorKind
- ensure errors.Unwrap exposes underlying error

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bf36743b18833386b1519c34cea00f