### PR TITLE
chore: update Go version for CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.24'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
## Summary
- use Go 1.24 in GitHub Actions workflow

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c4191077948333a32b44dbc6046e52